### PR TITLE
fix: exit ignores security bytes and CRC (#10)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   x86_64-linux-gnu-gcc:
-    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/x86_64-linux-gnu-gcc.yml@v0.0.8
+    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/x86_64-linux-gnu-gcc.yml@v0.0.9

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   license:
-    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/license-checker.yml@v0.0.8
+    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/license-checker.yml@v0.0.9

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   tests:
-    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/x86_64-linux-gnu-gcc.yml@v0.0.8
+    uses: ZIMO-Elektronik/.github-workflows/.github/workflows/x86_64-linux-gnu-gcc.yml@v0.0.9
     with:
       args: -DCMAKE_BUILD_TYPE=Debug
       target: ZUSITests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.9.2
+- Exit ignores security bytes and CRC ([#10](https://github.com/ZIMO-Elektronik/ZUSI/issues/10))
+
 ## 0.9.1
 - Make `tx::Base::busy` virtual
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ include(FetchContent)
 FetchContent_Declare(
   CMakeModules
   GIT_REPOSITORY "https://github.com/ZIMO-Elektronik/CMakeModules"
-  GIT_TAG v0.9.3
+  GIT_TAG v0.9.4
   SOURCE_DIR ${CMAKE_BINARY_DIR}/CMakeModules)
 FetchContent_MakeAvailable(CMakeModules)
 

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ Features requests the transmission capabilities of connected devices. Feature bi
   </tbody>
 </table>
 
-This will exit the ZUSI and resume normal operation.
+This will exit ZUSI and resume normal operation.
 
 #### ZPP-LC-DC-Query
 | Length | Name            | Value / Limits | Description                                                                                |

--- a/tests/rx/exit.cpp
+++ b/tests/rx/exit.cpp
@@ -1,0 +1,41 @@
+#include "rx_test.hpp"
+
+using namespace std::chrono_literals;
+
+// https://github.com/ZIMO-Elektronik/ZUSI/issues/10
+TEST_F(RxTest, exit_ignored_security_bytes_and_crc) {
+  zusi::Packet packet{std::to_underlying(zusi::Command::Exit), 1u, 2u, 0xFFu};
+
+  EXPECT_CALL(_mock, receiveByte())
+    .WillOnce(Return(packet[0uz]))
+    .WillOnce(Return(packet[1uz]))
+    .WillOnce(Return(packet[2uz]))
+    .WillOnce(Return(packet[3uz]))
+    .WillOnce(Return(zusi::crc8(packet)))
+    .WillOnce(Return(zusi::resync_byte))
+    .WillRepeatedly(Return(std::nullopt));
+  EXPECT_CALL(_mock, gpioOutput()).Times(1);
+  EXPECT_CALL(_mock, waitClock(_)).WillRepeatedly(Return(true));
+  EXPECT_CALL(_mock, exit(0xFFu)).Times(0);
+
+  RunFor(100ms);
+}
+
+TEST_F(RxTest, exit) {
+  zusi::Packet packet{
+    std::to_underlying(zusi::Command::Exit), 0x55u, 0xAAu, 0xFFu};
+
+  EXPECT_CALL(_mock, receiveByte())
+    .WillOnce(Return(packet[0uz]))
+    .WillOnce(Return(packet[1uz]))
+    .WillOnce(Return(packet[2uz]))
+    .WillOnce(Return(packet[3uz]))
+    .WillOnce(Return(zusi::crc8(packet)))
+    .WillOnce(Return(zusi::resync_byte))
+    .WillRepeatedly(Return(std::nullopt));
+  EXPECT_CALL(_mock, gpioOutput()).Times(1);
+  EXPECT_CALL(_mock, waitClock(_)).WillRepeatedly(Return(true));
+  EXPECT_CALL(_mock, exit(0xFFu)).Times(1);
+
+  RunFor(100ms);
+}


### PR DESCRIPTION
Fix #10 